### PR TITLE
ctrulib commit 9fe9493701a0ae86adc3f56d6d1cd318a5875d70 changed hidInit prototype

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -39,7 +39,7 @@ extern "C"
 		srvInit();
 		aptInit();
 		gfxInit(GSP_RGB565_OES, GSP_RGB565_OES, false);
-		hidInit(NULL);
+		hidInit();
 		fsInit();
 		sdmcArchiveInit();
 		amInit();


### PR DESCRIPTION
Built on 0.4.1 instead of master HEAD since I get zlib related errors from the added zip code from your latest commit.